### PR TITLE
Add a module for AWS ECS service

### DIFF
--- a/aws/ecs-ec2/README.md
+++ b/aws/ecs-ec2/README.md
@@ -1,0 +1,75 @@
+# terraform module ecs-ec2
+
+## Input Variables
+- `cluster_name` - Name of ECS cluster to deploy this ECS service on
+- `service_name` - Name of this ECS service
+- `alb_target_group_name` - Name of ALB target group. if doesn't use ALB, set this null
+- `alb_container_name` - Name of container bound to ALB target group
+- `alb_container_port` - Port of container bound to ALB target group
+- `container_definitions` - Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)
+- `task_num` - Number of tasks to be deployed
+- `deployment_min_percent` - Lower limit of tasks as a percentage
+- `deployment_max_percent` - Upper limit of tasks as a percentage
+
+## Usage
+```hcl
+locals {
+    image_tag = "1.0"
+}
+
+data "aws_ecr_repository" "api" {
+  name = "my-ecr-repo"
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/ecs/my-cluster/my-service"
+  retention_in_days = 7
+}
+
+module "api" {
+  source = "github.com/ridi/terraform-modules//aws/ecs-service"
+  
+  cluster_name = "my-cluster"
+  service_name = "my-service"
+        
+  alb_target_group_name = "my-alb"
+  alb_container_name = "app"
+  alb_container_port = 80
+  
+  container_definitions = [
+    {
+      name  = "app",
+      image = "${data.aws_ecr_repository.api.repository_url}:${local.image_tag}",
+      portMappings = [
+        { hostPort = 0, containerPort = 80 }
+      ],
+      environment = [
+        { name = "DOCKER_IMG_DIGEST", value = data.aws_ecr_image.api.image_digest },
+        { name = "DEBUG", value = "false" },
+      ],
+      secrets = [
+        { name = "DB_HOST", valueFrom = "/rds/host" },
+        { name = "DB_DBNAME", valueFrom = "/rds/db/my-service" },
+        { name = "DB_USER", valueFrom = "/rds/user/someone/username" },
+        { name = "DB_PASSWORD", valueFrom = "/rds/user/someone/password" },
+      ],
+      essential         = true
+      cpu               = 100,
+      memory            = 200,
+      memoryReservation = 100,
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-region        = "ap-northeast-2",
+          awslogs-group         = aws_cloudwatch_log_group.api.name,
+          awslogs-stream-prefix = local.image_tag
+        }
+      },
+    },
+  ]
+    
+  task_num = 2
+  deployment_min_percent = 50
+  deployment_max_percent = 200
+}
+```

--- a/aws/ecs-ec2/README.md
+++ b/aws/ecs-ec2/README.md
@@ -6,6 +6,7 @@
 - `alb_target_group_name` - Name of ALB target group. if doesn't use ALB, set this null
 - `alb_container_name` - Name of container bound to ALB target group
 - `alb_container_port` - Port of container bound to ALB target group
+- 'iam_exec_role_arn' - ARN of IAM role to execute this task
 - `container_definitions` - Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)
 - `task_num` - Number of tasks to be deployed
 - `deployment_min_percent` - Lower limit of tasks as a percentage

--- a/aws/ecs-ec2/main.tf
+++ b/aws/ecs-ec2/main.tf
@@ -34,5 +34,5 @@ resource "aws_ecs_task_definition" "this" {
 
   execution_role_arn = var.iam_exec_role_arn
 
-  container_definitions = jsonencode([var.container_definitions])
+  container_definitions = jsonencode(var.container_definitions)
 }

--- a/aws/ecs-ec2/main.tf
+++ b/aws/ecs-ec2/main.tf
@@ -1,0 +1,38 @@
+data "aws_lb_target_group" "this" {
+  count = var.alb_target_group_name == null ? 0 : 1
+  name  = var.alb_target_group_name
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.service_name
+  launch_type     = "EC2"
+  cluster         = var.cluster_name
+  task_definition = aws_ecs_task_definition.this.arn
+
+  desired_count                      = var.task_num
+  deployment_minimum_healthy_percent = var.deployment_min_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.alb_target_group_name == null ? [] : [data.aws_lb_target_group.this.*.arn[0]]
+
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = var.alb_container_name
+      container_port   = var.alb_container_port
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family = var.service_name
+
+  execution_role_arn = var.iam_exec_role_arn
+
+  container_definitions = jsonencode([var.container_definitions])
+}

--- a/aws/ecs-ec2/variables.tf
+++ b/aws/ecs-ec2/variables.tf
@@ -33,7 +33,7 @@ variable "iam_exec_role_arn" {
 
 variable "container_definitions" {
   description = "Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)"
-  type        = list(any)
+  type        = any
 }
 
 variable "task_num" {

--- a/aws/ecs-ec2/variables.tf
+++ b/aws/ecs-ec2/variables.tf
@@ -1,0 +1,50 @@
+variable "cluster_name" {
+  description = "Name of ECS cluster to deploy this ECS service on"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of this ECS service"
+  type        = string
+}
+
+variable "alb_target_group_name" {
+  description = "Name of ALB target group. if doesn't use ALB, set this null"
+  type        = string
+  default     = null
+}
+
+variable "alb_container_name" {
+  description = "Name of container bound to ALB target group"
+  type        = string
+  default     = "app"
+}
+
+variable "alb_container_port" {
+  description = "Port of container bound to ALB target group"
+  type        = number
+  default     = 80
+}
+
+variable "container_definitions" {
+  description = "Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)"
+  type        = list(map(string))
+}
+
+variable "task_num" {
+  description = "Number of tasks to be deployed"
+  type        = number
+  default     = 2
+}
+
+variable "deployment_min_percent" {
+  description = "Lower limit of tasks as a percentage"
+  type        = number
+  default     = 50
+}
+
+variable "deployment_max_percent" {
+  description = "Upper limit of tasks as a percentage"
+  type        = number
+  default     = 200
+}

--- a/aws/ecs-ec2/variables.tf
+++ b/aws/ecs-ec2/variables.tf
@@ -33,7 +33,7 @@ variable "iam_exec_role_arn" {
 
 variable "container_definitions" {
   description = "Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)"
-  type        = list(map(string))
+  type        = list(any)
 }
 
 variable "task_num" {

--- a/aws/ecs-ec2/variables.tf
+++ b/aws/ecs-ec2/variables.tf
@@ -26,6 +26,11 @@ variable "alb_container_port" {
   default     = 80
 }
 
+variable "iam_exec_role_arn" {
+  description = "ARN of IAM role to execute this task"
+  default     = null
+}
+
 variable "container_definitions" {
   description = "Definitions of each container. (See https://docs.aws.amazon.com/ko_kr/AmazonECS/latest/developerguide/create-task-definition.html)"
   type        = list(map(string))


### PR DESCRIPTION
It is only for EC2 mode. (Fargate is not included)