### PR TITLE
Accept volume block argument in task-definition

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -72,9 +72,10 @@ resource "aws_ecs_task_definition" "this" {
 
   dynamic "volume" {
     for_each = var.volumes[*]
+
     content {
-      name                 = volume.value.name
-      host_path            = volume.value.host_path
+      name      = volume.value.name
+      host_path = volume.value.host_path
     }
   }
 }

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -69,4 +69,12 @@ resource "aws_ecs_task_definition" "this" {
   network_mode             = local.task_network_mode
 
   container_definitions = jsonencode(var.container_definitions)
+
+  dynamic "volume" {
+    for_each = var.volumes[*]
+    content {
+      name                 = volume.value.name
+      host_path            = volume.value.host_path
+    }
+  }
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -106,3 +106,12 @@ variable "deployment_max_percent" {
   type        = number
   default     = 200
 }
+
+variable "volumes" {
+  description = "Docker volume block list"
+  type        = list(object({
+    name      = string
+    host_path = string
+  }))
+  default     = []
+}


### PR DESCRIPTION
Datadog agent를 ecs service로 배포하려고 하는데요, 만들어진 terraform 모듈을 가져다 쓰려고보니 volume block지원이 안되서 추가했습니다.