### PR TITLE
treat_missing_data 속성 추가

### DIFF
--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,7 +47,6 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
-      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "missing")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }
@@ -299,12 +298,12 @@ resource "aws_cloudwatch_metric_alarm" "http5xx" {
   metric_name = "HTTPCode_Target_5XX_Count"
 
   statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
   comparison_operator = "GreaterThanThreshold"
 
   threshold          = each.value.threshold
   period             = each.value.period
   evaluation_periods = each.value.evaluation_periods
-  treat_missing_data = each.value.treat_missing_data
 
   dimensions = {
     LoadBalancer = aws_alb.this.arn_suffix

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,7 +47,7 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
-      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "notBreaching")
+      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "missing")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,6 +47,7 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
+      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "notBreaching")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }
@@ -303,6 +304,7 @@ resource "aws_cloudwatch_metric_alarm" "http5xx" {
   threshold          = each.value.threshold
   period             = each.value.period
   evaluation_periods = each.value.evaluation_periods
+  treat_missing_data = each.value.treat_missing_data
 
   dimensions = {
     LoadBalancer = aws_alb.this.arn_suffix


### PR DESCRIPTION
##  추가사항
- target group 내 http5xx_alarm 에 `treat_missing_data` 속성을 추가하였습니다.


계속 데이터가 insufficient으로 노출되네요. 😞 로컬에서 테스트해봤을때 다른 알람들과 헷갈려서 미쳐 파악하지 못하였다가 프로덕션에 적용해보고 알게되어 MR 생성하였습니다. 🙏 
