### PR TITLE
Support a multiple target-group on ecs-service module

### DIFF
--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,6 +47,7 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
+      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "notBreaching")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }
@@ -304,6 +305,7 @@ resource "aws_cloudwatch_metric_alarm" "http5xx" {
   threshold          = each.value.threshold
   period             = each.value.period
   evaluation_periods = each.value.evaluation_periods
+  treat_missing_data = each.value.treat_missing_data
 
   dimensions = {
     LoadBalancer = aws_alb.this.arn_suffix

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,7 +47,7 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
-      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "notBreaching")
+      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "missing")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -47,7 +47,6 @@ locals {
       threshold          = lookup(target_group.http5xx_alarm, "threshold", 0)
       period             = lookup(target_group.http5xx_alarm, "period", 300)
       evaluation_periods = lookup(target_group.http5xx_alarm, "evaluation_periods", 1)
-      treat_missing_data = lookup(target_group.http5xx_alarm, "treat_missing_data", "missing")
     } if lookup(lookup(target_group, "http5xx_alarm", {}), "enabled", true)
   }
 }
@@ -305,7 +304,6 @@ resource "aws_cloudwatch_metric_alarm" "http5xx" {
   threshold          = each.value.threshold
   period             = each.value.period
   evaluation_periods = each.value.evaluation_periods
-  treat_missing_data = each.value.treat_missing_data
 
   dimensions = {
     LoadBalancer = aws_alb.this.arn_suffix

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -1,22 +1,23 @@
 # ecs-service
 
 ## Usage
+
 ```hcl
 module "service" {
   source = "github.com/ridi/terraform-modules//aws/ecs-service"
-  
+
   cluster_name = "my-cluster"
   service_name = "my-service"
-        
-  alb_target_group_name = "my-alb"
+
+  alb_target_group_names = ["my-alb", "my-second-alb"]
   alb_container_name    = "app"
   alb_container_port    = 80
-  
+
   # If you runs with EC2 type instead Fargate, ignore belows (launch_type, awsvpc_*).
   launch_type            = "FARGATE"
   awsvpc_subnet_ids      = data.aws_subnet_ids.private.ids
   awsvpc_security_groups = ["sg-1234abcd"]
-  
+
   volumes = [
     { name = "my-volume", host_path = "/ecs/my-service/app" }
   ]
@@ -55,7 +56,7 @@ module "service" {
       },
     },
   ]
-    
+
   task_num = 2
   deployment_min_percent = 50
   deployment_max_percent = 200
@@ -65,9 +66,11 @@ module "service" {
 ## Input Variables
 
 ### ECS Cluster
+
 - `cluster_name` - The name of ECS cluster to deploy ECS service on
 
 ### ECS Service
+
 - `service_name` - The name of this ECS service
 - `launch_type` - The launch type on which to run your service. ('EC2' or 'FARGATE')
 - `task_definition_arn` - The arn of task definition. If not set, creates new one. (container_definitions is required)
@@ -77,12 +80,14 @@ module "service" {
 - `awsvpc_subnet_ids` - The subnets associated with the task or service (task_network_mode)
 - `awsvpc_security_groups` - The security groups associated with the task or service
 - `awsvpc_assign_public_ip` - Whether assigns a public IP address to the ENI or not
-- `alb_target_group_name` - The name of ALB target group. if doesn't use ALB, set this null
+- `alb_target_group_names` - The name of ALB target group. if doesn't use ALB, skip or set to empty list
 - `alb_container_name` - The name of container bound to ALB target group
 - `alb_container_port` - The port of container bound to ALB target group
 
 ### ECS Task Definition
+
 These variables are ignored if `task_definition_arn` is set
+
 - `task_cpu` - The number of cpu units used by the task. (used in Fargate)
 - `task_memory` - The amount (in MB) of memory used by the task. (used in Fargate)
 - `task_network_mode` - The Docker networking mode to use for the containers in the task. ('none', 'bridge', 'awsvpc', 'host')

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -11,8 +11,8 @@ locals {
 }
 
 data "aws_lb_target_group" "this" {
-  count = var.alb_target_group_name == null ? 0 : 1
-  name  = var.alb_target_group_name
+  count = length(var.alb_target_group_names)
+  name  = var.alb_target_group_names[count.index]
 }
 
 resource "aws_ecs_service" "this" {
@@ -45,7 +45,7 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "load_balancer" {
-    for_each = var.alb_target_group_name == null ? [] : [data.aws_lb_target_group.this.*.arn[0]]
+    for_each = data.aws_lb_target_group.this.*.arn
 
     content {
       target_group_arn = load_balancer.value

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -56,10 +56,10 @@ variable "awsvpc_assign_public_ip" {
   default     = null
 }
 
-variable "alb_target_group_name" {
-  description = "The name of ALB target group. if doesn't use ALB, set this null"
-  type        = string
-  default     = null
+variable "alb_target_group_names" {
+  description = "The name of ALB target groups. if doesn't use ALB, set this null"
+  type        = list(any)
+  default     = []
 }
 
 variable "alb_container_name" {


### PR DESCRIPTION
## 개요 
ecs-service 모듈 내 다중 타겟 그룹 지원하도록 변경하였습니다.

## 변경사항
기존 인터페이스에서 큰 변화 없이 alb_target_group_name(string)을 alb_target_group_names(list) 으로 변경하였습니다.